### PR TITLE
build: Add convenience script to download expo bins for *nix machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,7 @@ Sample React-Native application with e2e tests using:
 
 ## Installation instructions
 1. Follow **Step 1** (install dependencies) from detox [Getting Started](https://github.com/wix/detox/blob/master/docs/Introduction.GettingStarted.md#step-1-install-dependencies) guide
-2. Download Expo iOS client:
-    - Download the Expo Client iOS App from [Expo.io/tools](https://expo.io/tools#client).
-    - Unzip the iOS IPA and **rename the folder** to `Exponent.app`. It'll have a file icon but will still be a folder.
-    - Create `bin` folder in this project and put `Exponent.app` inside so it matches the binaryPath set above.
+2. Download Expo iOS client by running `npm run dl_expo_bins`
 3. Install the project dependencies by running `npm install`.
 4. Start the application by running `npm start`.
 5. In another terminal, run `npm run e2e` to run the tests.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "eject": "expo eject",
-    "e2e": "detox test --configuration ios.sim"
+    "e2e": "detox test --configuration ios.sim",
+    "dl_expo_bins": "./scripts/dl_expo_bins"
   },
   "dependencies": {
     "expo": "^33.0.0",

--- a/scripts/dl_expo_bins
+++ b/scripts/dl_expo_bins
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -eo pipefail
+
+# query expo.io to find most recent ipaUrl
+IPA_URL=$(curl -sS https://expo.io/--/api/v2/versions | python -c 'import sys, json; print json.load(sys.stdin)["iosUrl"]')
+# Skipping android apk dl for now
+# APK_URL=$(curl -sS https://expo.io/--/api/v2/versions | python -c 'import sys, json; print json.load(sys.stdin)["androidUrl"]')
+
+# download tar.gz
+TMP_PATH_IPA=/tmp/exponent-app.tar.gz
+curl -o $TMP_PATH_IPA "$IPA_URL"
+
+# recursively make app dir
+APP_PATH=bin/Exponent.app
+mkdir -p $APP_PATH
+
+# create apk (isn't stored tar'd)
+# APK_PATH=bin/Exponent.apk
+# curl -o $APK_PATH "$APK_URL"
+
+# unzip tar.gz into APP_PATH
+tar -C $APP_PATH -xzf $TMP_PATH_IPA


### PR DESCRIPTION
Thanks for this example 👍 . Looking forward to getting detox+expo running beyond 12.3 🚀 

Here's a convenience script to save the hassle of downloading the expo bins manually. Only works on linux and mac but not sure you'd use detox/expo in another context yet.